### PR TITLE
Plugin respects the 'watch' setting of parcelConfig

### DIFF
--- a/src/plugin.Spec.ts
+++ b/src/plugin.Spec.ts
@@ -229,7 +229,8 @@ describe("plugin", () => {
           karmaConf.parcelConfig = {
             cacheDir: "/path/to/cache",
             detailedReport: true,
-            logLevel: 2
+            logLevel: 2,
+            watch: true
           };
 
           plugin.middleware(req, resp, sinon.stub());

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -17,7 +17,7 @@ export type KarmaConf = karma.ConfigOptions &
   karma.Config & {
     parcelConfig?: Pick<
       ParcelOptions,
-      "cacheDir" | "detailedReport" | "logLevel"
+      "cacheDir" | "detailedReport" | "logLevel" | "watch"
     >;
   };
 

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -107,11 +107,11 @@ export class ParcelPlugin {
         detailedReport: false,
         logLevel: 1,
         outDir: dir,
+        watch: this.isWatching(),
         ...this.karmaConf.parcelConfig,
         // config that should not be overriden
         outFile: bundleFile,
         publicUrl: "/karma-parcel",
-        watch: this.isWatching(),
         hmr: false,
         autoinstall: false
       },


### PR DESCRIPTION
When running tests with the IntellIJ Karma plugin, autoWatch is forcibly set to false. That means that the Karma Parcel plugin runs Parcel with `watch: false` as well. So Parcel doesn't kick in when modifying a test, and you need to restart the Karma server to see you changes.

This PR takes the `watch` setting that's specified on `parcelConfig`. If it's not there, we use the default value (determined by `ParcelPlugin.isWatching()`)