### PR TITLE
fix: #25 Double import in the Entry.js

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,2 @@
+[*.ts]
+indent_size = 2

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "karma-parcel",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Parcel tests to Karma",
   "main": "dist/index.js",
   "scripts": {

--- a/src/files.Spec.ts
+++ b/src/files.Spec.ts
@@ -87,11 +87,12 @@ describe("files", () => {
     it("allows addition of files", () => {
       return workspace().then(w => {
         const file = w.entryFile;
+        const tmpDir = path.dirname(path.dirname(file.path))
         return file
-          .add("/path/to/file")
+          .add(tmpDir + "/path/to/file")
           .then(() => promisify(fs.readFile)(file.path))
           .then(cont => {
-            assert.equal(cont.toString("utf8"), `import "../../path/to/file";`);
+            assert.equal(cont.toString("utf8"), `import "../path/to/file";`);
           });
       });
     });
@@ -110,12 +111,12 @@ describe("files", () => {
           const file = createWorkspaceSync().entryFile;
 
           return file
-            .add("/path/other/file")
+            .add(tmpDir + "/path/other/file")
             .then(() => promisify(fs.readFile)(file.path))
             .then(cont => {
               assert.equal(
                 cont.toString("utf8"),
-                `import "../../../path/other/file";`
+                `import "../path/other/file";`
               );
             });
         });

--- a/src/files.Spec.ts
+++ b/src/files.Spec.ts
@@ -97,6 +97,21 @@ describe("files", () => {
       });
     });
 
+    it("filters out double entries", () => {
+      return workspace().then(w => {
+        const file = w.entryFile
+        const tmpDir = path.dirname(path.dirname(file.path))
+        return Promise.all([
+          file.add(tmpDir + "/path/to/file"),
+          file.add(tmpDir + "/path/to/file"),
+        ])
+          .then(() => promisify(fs.readFile)(file.path))
+          .then(cont => {
+            assert.equal(cont.toString("utf8"), `import "../path/to/file";`);
+          });
+      });
+    });
+
     it("adds the files relative to the dir", () => {
       const tmpDir = path.join(os.tmpdir(), "karma-parcel-tmp");
 

--- a/src/files.ts
+++ b/src/files.ts
@@ -54,6 +54,7 @@ export class EntryFile extends TmpFile {
   }
 
   add(path: string) {
+    if (this.files.indexOf(path) >= 0) return Promise.resolve();
     this.files.push(path);
     const content = this.files
       .map(f => `import "${this.importPath(f)}";`)


### PR DESCRIPTION
## Changes
- Adding a simple Editorconfig
- Fixing Test cases so it would work in any environment
- Adding a Test around the double import issue
- Fixing issue #25

## Info
I've had issues running the tests as they were because it seems that the temp location is different on Mac than what's been assumed. This was fixed simply by using the temp path instead of assuming that location is going to be on the same level for every system. This seems to work fine: https://github.com/adaliszk/karma-parcel/actions/runs/549985303

To fix #25, I've added the test case and a very simple fix. I've bumped the version so it could be released afterwards. 